### PR TITLE
Restore finding master on golett

### DIFF
--- a/lib/vsc/manage/managecommands.py
+++ b/lib/vsc/manage/managecommands.py
@@ -590,7 +590,7 @@ class PBSStateCommand(SshCommand):
         """
         constructor
         """
-        SshCommand.__init__(self, command='pbsnodes | grep -v status', host=host, user='root', timeout=timeout)
+        SshCommand.__init__(self, command="pbsnodes | grep -v 'status\|jobs'", host=host, user='root', timeout=timeout)
         self.masternode = host
 
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-manage',
-    'version': '1.7.1',
+    'version': '1.7.2',
     'author': [jt],
     'maintainer': [jt],
     'packages': ['vsc', 'vsc.manage'],


### PR DESCRIPTION
failed due to too much output when job info was also shipped